### PR TITLE
Add aurora wave wall reflection effect

### DIFF
--- a/miniLightShow.ino
+++ b/miniLightShow.ino
@@ -15,9 +15,15 @@ void setup() {
 void loop() {
   twinkle(strip.Color(8, 8, 8), strip.Color(255, 255, 255), 60, 40);
 
+  auroraWave(strip.Color(12, 4, 32), strip.Color(0, 64, 48), 6, 6);
+
   twinkle(strip.Color(8, 0, 0), strip.Color(255, 0, 0), 60, 40);
   twinkle(strip.Color(0, 8, 0), strip.Color(0, 255, 0), 60, 40);
   twinkle(strip.Color(0, 0, 8), strip.Color(0, 0, 255), 60, 40);
+
+  auroraWave(strip.Color(8, 0, 0), strip.Color(255, 0, 0), 6, 6);
+  auroraWave(strip.Color(0, 8, 0), strip.Color(0, 255, 0), 6, 6);
+  auroraWave(strip.Color(0, 0, 8), strip.Color(0, 0, 255), 6, 6);
 
   twinkle(strip.Color(32, 0, 0), strip.Color(random(0, 256), random(0, 256), random(0, 256)), 60, 40);
   twinkle(strip.Color(0, 32, 0), strip.Color(random(0, 256), random(0, 256), random(0, 256)), 60, 40);
@@ -39,7 +45,12 @@ void loop() {
   twinkle(strip.Color(0, 64, 0), strip.Color(0, 255, 0), 60, 40);
   twinkle(strip.Color(0, 0, 64), strip.Color(0, 0, 255), 60, 40);
 
+  auroraWave(strip.Color(64, 0, 0), strip.Color(255, 0, 0), 6, 6);
+  auroraWave(strip.Color(0, 64, 0), strip.Color(0, 255, 0), 6, 6);
+  auroraWave(strip.Color(0, 0, 64), strip.Color(0, 0, 255), 6, 6);
+
   breathe(strip.Color(random(0, 256), random(0, 256), random(0, 256)));
+  auroraWave(strip.Color(random(0, 256), random(0, 256), random(0, 256)), strip.Color(random(0, 256), random(0, 256), random(0, 256)), 6, 6);
   chase(strip.Color(random(0, 256), 0, 0)); // Random red
   chase(strip.Color(0, random(0, 256), 0)); // Random green
   chase(strip.Color(0, 0, random(0, 256))); // Random blue

--- a/miniLightShow.ino
+++ b/miniLightShow.ino
@@ -100,6 +100,8 @@ void loop() {
   cycle_blue();
   chase(strip.Color(0, 0, 255)); // Blue
 
+  auroraWave(strip.Color(12, 4, 32), strip.Color(0, 64, 48), 6, 6);
+
   twinkle(strip.Color(8, 8, 8), strip.Color(255, 255, 255), 60, 40);
 }
 
@@ -183,6 +185,51 @@ static void cycle_blue() {
     }
     strip.show();
     delay(100);
+  }
+}
+
+static uint32_t blendColors(uint32_t c1, uint32_t c2, uint8_t amount) {
+  uint8_t r1 = (uint8_t)(c1 >> 16);
+  uint8_t g1 = (uint8_t)(c1 >> 8);
+  uint8_t b1 = (uint8_t)c1;
+  uint8_t r2 = (uint8_t)(c2 >> 16);
+  uint8_t g2 = (uint8_t)(c2 >> 8);
+  uint8_t b2 = (uint8_t)c2;
+
+  uint16_t inverse = 255 - amount;
+
+  uint8_t r = (uint8_t)(((uint16_t)r1 * inverse + (uint16_t)r2 * amount) / 255);
+  uint8_t g = (uint8_t)(((uint16_t)g1 * inverse + (uint16_t)g2 * amount) / 255);
+  uint8_t b = (uint8_t)(((uint16_t)b1 * inverse + (uint16_t)b2 * amount) / 255);
+
+  return strip.Color(r, g, b);
+}
+
+static void auroraWave(uint32_t colorA, uint32_t colorB, uint8_t waveSpeed, uint8_t passes) {
+  strip.setBrightness(127);
+
+  if(waveSpeed == 0) {
+    waveSpeed = 1;
+  }
+  if(passes == 0) {
+    passes = 1;
+  }
+
+  uint16_t pixelCount = strip.numPixels();
+  if(pixelCount == 0) {
+    return;
+  }
+
+  for(uint16_t step=0; step<(uint16_t)passes * 256; step += waveSpeed) {
+    for(uint16_t i=0; i<pixelCount; i++) {
+      uint16_t base = ((uint16_t)i * 256) / pixelCount;
+      uint8_t wave = (uint8_t)(base + step);
+      uint8_t blendAmount = wave < 128 ? (uint8_t)(wave * 2) : (uint8_t)((255 - wave) * 2);
+      uint32_t blended = blendColors(colorA, colorB, blendAmount);
+      strip.setPixelColor(i, blended);
+    }
+    strip.show();
+    delay(35);
   }
 }
 


### PR DESCRIPTION
## Summary
- add an auroraWave pattern that sweeps a soft gradient across the strip for wall reflections
- introduce a reusable color blending helper to smoothly mix colors as the wave progresses

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf686ec9b883218c04e989516afcd1